### PR TITLE
Course repository refactor

### DIFF
--- a/schoolmanager-backend/src/main/java/apt/project/backend/repository/CourseRepository.java
+++ b/schoolmanager-backend/src/main/java/apt/project/backend/repository/CourseRepository.java
@@ -60,10 +60,6 @@ public class CourseRepository implements Repository<Course> {
         return result.get(0);
     }
 
-    public void deleteByTitle(String titleToDelete) {
-        return;
-    }
-
     @Override
     public Course findById(Long id) {
         entityManager.getTransaction().begin();

--- a/schoolmanager-backend/src/main/java/apt/project/backend/repository/CourseRepository.java
+++ b/schoolmanager-backend/src/main/java/apt/project/backend/repository/CourseRepository.java
@@ -64,4 +64,12 @@ public class CourseRepository implements Repository<Course> {
         return;
     }
 
+    @Override
+    public Course findById(Long id) {
+        entityManager.getTransaction().begin();
+        Course course = entityManager.find(Course.class, id);
+        entityManager.getTransaction().commit();
+
+        return course;
+    }
 }

--- a/schoolmanager-backend/src/main/java/apt/project/backend/repository/Repository.java
+++ b/schoolmanager-backend/src/main/java/apt/project/backend/repository/Repository.java
@@ -13,4 +13,6 @@ public interface Repository<T extends BaseEntity> {
     void delete(T e);
 
     public void update(T modifiedEntity);
+
+    public T findById(Long id);
 }

--- a/schoolmanager-backend/src/test/java/apt/project/backend/repository/CourseRepositoryTest.java
+++ b/schoolmanager-backend/src/test/java/apt/project/backend/repository/CourseRepositoryTest.java
@@ -142,4 +142,17 @@ public class CourseRepositoryTest {
         assertThat(retrievedCourse)
                 .isEqualToComparingFieldByField(existingCourse);
     }
+
+    @Test
+    public void testFindById() {
+        // setup
+        Course course = new Course("Course1");
+        entityManager.getTransaction().begin();
+        entityManager.persist(course);
+        entityManager.getTransaction().commit();
+        // exercise
+        Course retrievedCourse = courseRepository.findById(course.getId());
+        // verify
+        assertThat(course).isEqualTo(retrievedCourse);
+    }
 }

--- a/schoolmanager-frontend/src/main/java/apt/project/frontend/controller/CourseController.java
+++ b/schoolmanager-frontend/src/main/java/apt/project/frontend/controller/CourseController.java
@@ -36,18 +36,18 @@ public class CourseController implements Controller<Course> {
 
     @Override
     public void deleteEntity(Course courseToDelete) {
-        if (courseRepository.findByTitle(courseToDelete.getTitle()) == null) {
+        if (courseRepository.findById(courseToDelete.getId()) == null) {
             courseView.showError("No existing course with title "
                     + courseToDelete.getTitle(), courseToDelete);
             return;
         }
-        courseRepository.deleteByTitle(courseToDelete.getTitle());
+        courseRepository.delete(courseToDelete);
         courseView.entityDeleted(courseToDelete);
     }
 
     @Override
     public void updateEntity(Course existingCourse, Course modifiedCourse) {
-        if (courseRepository.findByTitle(existingCourse.getTitle()) == null) {
+        if (courseRepository.findById(existingCourse.getId()) == null) {
             courseView.showError("No existing course with title "
                     + existingCourse.getTitle(), existingCourse);
             return;

--- a/schoolmanager-frontend/src/test/java/apt/project/frontend/controller/CourseControllerTest.java
+++ b/schoolmanager-frontend/src/test/java/apt/project/frontend/controller/CourseControllerTest.java
@@ -1,6 +1,7 @@
 package apt.project.frontend.controller;
 
 import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.ignoreStubs;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
@@ -76,13 +77,13 @@ public class CourseControllerTest {
     public void testDeleteCourseWhenCourseExists() {
         // setup
         Course courseToDelete = new Course("Course_1");
-        when(courseRepository.findByTitle("Course_1"))
+        when(courseRepository.findById((Long) any()))
                 .thenReturn(courseToDelete);
         // exercise
         courseController.deleteEntity(courseToDelete);
         // verify
         InOrder inOrder = inOrder(courseRepository, courseView);
-        inOrder.verify(courseRepository).deleteByTitle("Course_1");
+        inOrder.verify(courseRepository).delete(courseToDelete);
         inOrder.verify(courseView).entityDeleted(courseToDelete);
     }
 
@@ -90,7 +91,7 @@ public class CourseControllerTest {
     public void testDeleteCourseWhenCourseDoesNotExists() {
         // setup
         Course courseToDelete = new Course("Course_2");
-        when(courseRepository.findByTitle("Course_2")).thenReturn(null);
+        when(courseRepository.findById((Long) any())).thenReturn(null);
         // exercise
         courseController.deleteEntity(courseToDelete);
         // verify
@@ -104,7 +105,7 @@ public class CourseControllerTest {
         // setup
         Course existingCourse = new Course("existingTitle");
         Course modifiedCourse = new Course("modifiedTitle");
-        when(courseRepository.findByTitle("existingTitle"))
+        when(courseRepository.findById((Long) any()))
                 .thenReturn(existingCourse);
         // exercise
         courseController.updateEntity(existingCourse, modifiedCourse);
@@ -120,7 +121,7 @@ public class CourseControllerTest {
         // setup
         Course existingCourse = new Course("existingTitle");
         Course modifiedCourse = new Course("modifiedTitle");
-        when(courseRepository.findByTitle("existingTitle")).thenReturn(null);
+        when(courseRepository.findById((Long) any())).thenReturn(null);
         // exercise
         courseController.updateEntity(existingCourse, modifiedCourse);
         // verify


### PR DESCRIPTION
Refactoring of the repository (and subsequently controller) to use methods with generated id values.

For example now we have `findById` instead of `findByTitle` to retrieve a single entity from the database. Actually we kept findByTitle because we need it when we create a new entity with `new`: the `id` is generated after persistence, so we search by title to see if there is already another entity with the same title.